### PR TITLE
Deep reflection: flatten anonymous inner struct members

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -8,9 +8,14 @@ import (
 )
 
 type MyStruct struct {
+	MyEmbeddedStruct
 	FirstField  string `matched:"first tag"`
 	SecondField int    `matched:"second tag"`
 	ThirdField  string `unmatched:"third tag"`
+}
+
+type MyEmbeddedStruct struct {
+	EmbeddedField string
 }
 
 func ExampleGetField() {
@@ -117,6 +122,25 @@ func ExampleItems() {
 	// Items will return a field name to
 	// field value map
 	structItems, _ = reflections.Items(s)
+	fmt.Println(structItems)
+}
+
+func ExampleItemsDeep() {
+	s := MyStruct{
+		FirstField:  "first value",
+		SecondField: 2,
+		ThirdField:  "third value",
+		MyEmbeddedStruct: MyEmbeddedStruct{
+			EmbeddedField: "embedded value",
+		},
+	}
+
+	var structItems map[string]interface{}
+
+	// ItemsDeep will return a field name to
+	// field value map, including fields from
+	// anonymous embedded structs
+	structItems, _ = reflections.ItemsDeep(s)
 	fmt.Println(structItems)
 }
 

--- a/reflections.go
+++ b/reflections.go
@@ -61,7 +61,7 @@ func GetFieldTag(obj interface{}, fieldName, tagKey string) (string, error) {
 
 	objValue := reflectValue(obj)
 	objType := objValue.Type()
-	
+
 	field, ok := objType.FieldByName(fieldName)
 	if !ok {
 		return "", fmt.Errorf("No such field: %s in obj", fieldName)
@@ -122,6 +122,16 @@ func HasField(obj interface{}, name string) (bool, error) {
 // Fields returns the struct fields names list. obj can whether
 // be a structure or pointer to structure.
 func Fields(obj interface{}) ([]string, error) {
+	return fields(obj, false)
+}
+
+// FieldsDeep returns "flattened" fields (fields from anonymous
+// inner structs are treated as normal fields)
+func FieldsDeep(obj interface{}) ([]string, error) {
+	return fields(obj, true)
+}
+
+func fields(obj interface{}, deep bool) ([]string, error) {
 	if !hasValidType(obj, []reflect.Kind{reflect.Struct, reflect.Ptr}) {
 		return nil, errors.New("Cannot use GetField on a non-struct interface")
 	}
@@ -130,20 +140,37 @@ func Fields(obj interface{}) ([]string, error) {
 	objType := objValue.Type()
 	fieldsCount := objType.NumField()
 
-	var fields []string
+	var allFields []string
 	for i := 0; i < fieldsCount; i++ {
 		field := objType.Field(i)
-		if isExportableField(field) {
-			fields = append(fields, field.Name)
+		if deep && field.Anonymous {
+			fieldValue := objValue.Field(i)
+			subFields, err := fields(fieldValue.Interface(), deep)
+			if err != nil {
+				return nil, fmt.Errorf("Cannot get fields in %s: %s", field.Name, err.Error())
+			}
+			allFields = append(allFields, subFields...)
+		} else if isExportableField(field) {
+			allFields = append(allFields, field.Name)
 		}
 	}
 
-	return fields, nil
+	return allFields, nil
 }
 
 // Items returns the field - value struct pairs as a map. obj can whether
 // be a structure or pointer to structure.
 func Items(obj interface{}) (map[string]interface{}, error) {
+	return items(obj, false)
+}
+
+// FieldsDeep returns "flattened" items (fields from anonymous
+// inner structs are treated as normal fields)
+func ItemsDeep(obj interface{}) (map[string]interface{}, error) {
+	return items(obj, true)
+}
+
+func items(obj interface{}, deep bool) (map[string]interface{}, error) {
 	if !hasValidType(obj, []reflect.Kind{reflect.Struct, reflect.Ptr}) {
 		return nil, errors.New("Cannot use GetField on a non-struct interface")
 	}
@@ -152,25 +179,40 @@ func Items(obj interface{}) (map[string]interface{}, error) {
 	objType := objValue.Type()
 	fieldsCount := objType.NumField()
 
-	items := make(map[string]interface{})
+	allItems := make(map[string]interface{})
 
 	for i := 0; i < fieldsCount; i++ {
 		field := objType.Field(i)
 		fieldValue := objValue.Field(i)
-
-		// Make sure only exportable and addressable fields are
-		// returned by Items
-		if isExportableField(field) {
-			items[field.Name] = fieldValue.Interface()
+		if deep && field.Anonymous {
+			if m, err := items(fieldValue.Interface(), deep); err == nil {
+				for k, v := range m {
+					allItems[k] = v
+				}
+			} else {
+				return nil, fmt.Errorf("Cannot get items in %s: %s", field.Name, err.Error())
+			}
+		} else if isExportableField(field) {
+			allItems[field.Name] = fieldValue.Interface()
 		}
 	}
 
-	return items, nil
+	return allItems, nil
 }
 
 // Tags lists the struct tag fields. obj can whether
 // be a structure or pointer to structure.
 func Tags(obj interface{}, key string) (map[string]string, error) {
+	return tags(obj, key, false)
+}
+
+// FieldsDeep returns "flattened" tags (fields from anonymous
+// inner structs are treated as normal fields)
+func TagsDeep(obj interface{}, key string) (map[string]string, error) {
+	return tags(obj, key, true)
+}
+
+func tags(obj interface{}, key string, deep bool) (map[string]string, error) {
 	if !hasValidType(obj, []reflect.Kind{reflect.Struct, reflect.Ptr}) {
 		return nil, errors.New("Cannot use GetField on a non-struct interface")
 	}
@@ -179,29 +221,37 @@ func Tags(obj interface{}, key string) (map[string]string, error) {
 	objType := objValue.Type()
 	fieldsCount := objType.NumField()
 
-	tags := make(map[string]string)
+	allTags := make(map[string]string)
 
 	for i := 0; i < fieldsCount; i++ {
 		structField := objType.Field(i)
-
-		if isExportableField(structField) {
-			tags[structField.Name] = structField.Tag.Get(key)
+		if deep && structField.Anonymous {
+			fieldValue := objValue.Field(i)
+			if m, err := tags(fieldValue.Interface(), key, deep); err == nil {
+				for k, v := range m {
+					allTags[k] = v
+				}
+			} else {
+				return nil, fmt.Errorf("Cannot get items in %s: %s", structField.Name, err.Error())
+			}
+		} else if isExportableField(structField) {
+			allTags[structField.Name] = structField.Tag.Get(key)
 		}
 	}
 
-	return tags, nil
+	return allTags, nil
 }
 
 func reflectValue(obj interface{}) reflect.Value {
-    var val reflect.Value
+	var val reflect.Value
 
-    if reflect.TypeOf(obj).Kind() == reflect.Ptr {
-        val = reflect.ValueOf(obj).Elem()
-    } else {
-        val = reflect.ValueOf(obj)
-    }
+	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		val = reflect.ValueOf(obj).Elem()
+	} else {
+		val = reflect.ValueOf(obj)
+	}
 
-    return val
+	return val
 }
 
 func isExportableField(field reflect.StructField) bool {
@@ -209,7 +259,7 @@ func isExportableField(field reflect.StructField) bool {
 	return field.PkgPath == ""
 }
 
-func hasValidType(obj interface{}, types []reflect.Kind) bool{
+func hasValidType(obj interface{}, types []reflect.Kind) bool {
 	for _, t := range types {
 		if reflect.TypeOf(obj).Kind() == t {
 			return true

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -379,8 +379,8 @@ func TestItems_on_non_struct(t *testing.T) {
 
 func TestItems_deep(t *testing.T) {
 	p := Person{}
-	p.Name = "name!"
-	p.Street = "street?"
+	p.Name = "John"
+	p.Street = "Decumanus maximus"
 	p.Number = 17
 
 	items, err := Items(p)
@@ -390,15 +390,15 @@ func TestItems_deep(t *testing.T) {
 
 	assert.Equal(t, len(items), 2)
 	assert.Equal(t, len(itemsDeep), 3)
-	assert.Equal(t, itemsDeep["Name"], "name!")
-	assert.Equal(t, itemsDeep["Street"], "street?")
+	assert.Equal(t, itemsDeep["Name"], "John")
+	assert.Equal(t, itemsDeep["Street"], "Decumanus maximus")
 	assert.Equal(t, itemsDeep["Number"], 17)
 }
 
 func TestTags_deep(t *testing.T) {
 	p := Person{}
-	p.Name = "name!"
-	p.Street = "street?"
+	p.Name = "John"
+	p.Street = "Decumanus maximus"
 	p.Number = 17
 
 	tags, err := Tags(p, "tag")
@@ -415,7 +415,7 @@ func TestTags_deep(t *testing.T) {
 
 func TestFields_deep(t *testing.T) {
 	p := Person{}
-	p.Name = "name!"
+	p.Name = "John"
 	p.Street = "street?"
 	p.Number = 17
 

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -16,19 +16,6 @@ type TestStruct struct {
 	Yummy      int    `test:"yummytag"`
 }
 
-type Address struct {
-	Street string `tag:"be"`
-	Number int    `tag:"bi"`
-}
-
-type unexportedStruct struct{}
-
-type Person struct {
-	Name string `tag:"bu"`
-	Address
-	unexportedStruct
-}
-
 func TestGetField_on_struct(t *testing.T) {
 	dummyStruct := TestStruct{
 		Dummy: "test",
@@ -378,6 +365,19 @@ func TestItems_on_non_struct(t *testing.T) {
 }
 
 func TestItems_deep(t *testing.T) {
+	type Address struct {
+		Street string `tag:"be"`
+		Number int    `tag:"bi"`
+	}
+
+	type unexportedStruct struct{}
+
+	type Person struct {
+		Name string `tag:"bu"`
+		Address
+		unexportedStruct
+	}
+
 	p := Person{}
 	p.Name = "John"
 	p.Street = "Decumanus maximus"
@@ -396,6 +396,19 @@ func TestItems_deep(t *testing.T) {
 }
 
 func TestTags_deep(t *testing.T) {
+	type Address struct {
+		Street string `tag:"be"`
+		Number int    `tag:"bi"`
+	}
+
+	type unexportedStruct struct{}
+
+	type Person struct {
+		Name string `tag:"bu"`
+		Address
+		unexportedStruct
+	}
+
 	p := Person{}
 	p.Name = "John"
 	p.Street = "Decumanus maximus"
@@ -414,6 +427,19 @@ func TestTags_deep(t *testing.T) {
 }
 
 func TestFields_deep(t *testing.T) {
+	type Address struct {
+		Street string `tag:"be"`
+		Number int    `tag:"bi"`
+	}
+
+	type unexportedStruct struct{}
+
+	type Person struct {
+		Name string `tag:"bu"`
+		Address
+		unexportedStruct
+	}
+
 	p := Person{}
 	p.Name = "John"
 	p.Street = "street?"

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -6,14 +6,24 @@ package reflections
 
 import (
 	"github.com/stretchr/testify/assert"
-	"testing"
 	"reflect"
+	"testing"
 )
 
 type TestStruct struct {
 	unexported uint64
 	Dummy      string `test:"dummytag"`
 	Yummy      int    `test:"yummytag"`
+}
+
+type Address struct {
+	Street string `tag:"be"`
+	Number int    `tag:"bi"`
+}
+
+type Person struct {
+	Name string `tag:"bu"`
+	Address
 }
 
 func TestGetField_on_struct(t *testing.T) {
@@ -362,4 +372,58 @@ func TestItems_on_non_struct(t *testing.T) {
 
 	_, err := Items(dummy)
 	assert.Error(t, err)
+}
+
+func TestItems_deep(t *testing.T) {
+	p := Person{}
+	p.Name = "name!"
+	p.Street = "street?"
+	p.Number = 17
+
+	items, err := Items(p)
+	assert.NoError(t, err)
+	itemsDeep, err := ItemsDeep(p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(items), 2)
+	assert.Equal(t, len(itemsDeep), 3)
+	assert.Equal(t, itemsDeep["Name"], "name!")
+	assert.Equal(t, itemsDeep["Street"], "street?")
+	assert.Equal(t, itemsDeep["Number"], 17)
+}
+
+func TestTags_deep(t *testing.T) {
+	p := Person{}
+	p.Name = "name!"
+	p.Street = "street?"
+	p.Number = 17
+
+	tags, err := Tags(p, "tag")
+	assert.NoError(t, err)
+	tagsDeep, err := TagsDeep(p, "tag")
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(tags), 2)
+	assert.Equal(t, len(tagsDeep), 3)
+	assert.Equal(t, tagsDeep["Name"], "bu")
+	assert.Equal(t, tagsDeep["Street"], "be")
+	assert.Equal(t, tagsDeep["Number"], "bi")
+}
+
+func TestFields_deep(t *testing.T) {
+	p := Person{}
+	p.Name = "name!"
+	p.Street = "street?"
+	p.Number = 17
+
+	fields, err := Fields(p)
+	assert.NoError(t, err)
+	fieldsDeep, err := FieldsDeep(p)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(fields), 2)
+	assert.Equal(t, len(fieldsDeep), 3)
+	assert.Equal(t, fieldsDeep[0], "Name")
+	assert.Equal(t, fieldsDeep[1], "Street")
+	assert.Equal(t, fieldsDeep[2], "Number")
 }

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -21,9 +21,12 @@ type Address struct {
 	Number int    `tag:"bi"`
 }
 
+type unexportedStruct struct{}
+
 type Person struct {
 	Name string `tag:"bu"`
 	Address
+	unexportedStruct
 }
 
 func TestGetField_on_struct(t *testing.T) {


### PR DESCRIPTION
This PR adds `*Deep(...)` methods. Those methods flatten anonymous inner structs.

For example:

```
type Address struct {
	Street string `tag:"be"`
	Number int    `tag:"bi"`
}

type Person struct {
	Name string `tag:"bu"`
	Address
}
```
When a user is created in Go, the `Street` is more-or-less a normal field:
```
p := Persion{}
p.Street = "Somewhere"
```
But the current library behaviour is to treat `Address` like a field, not `Street`.

When using `*Deep(...)` functions, fields from anonymous inner structs will be treated like normal fields.