### PR TITLE
Add GetFieldType function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ provide *GetField* a structure or a pointer to structure as first argument.
     }
 ```
 
+##### GetFieldType
+
+*GetFieldType* returns the string literal of a structure field type. It can be used to operate type assertion over a structure fields at runtime.  You can whether provide *GetFieldType* a structure or a pointer to structure as first argument.
+
+```go
+    s := MyStruct{
+        FirstField:  "first value",
+        SecondField: 2,
+        ThirdField:  "third value",
+    }
+
+    var firstFieldKind string
+    var secondFieldKind string
+    var err error
+
+    firstFieldKind, err = GetFieldType(s, "FirstField")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    secondFieldKind, err = GetFieldType(s, "SecondField")
+    if err != nil {
+        log.Fatal(err)
+    }
+```
+
 ##### GetFieldTag
 
 *GetFieldTag* extracts a specific structure field tag. You can whether provide *GetFieldTag* a structure or a pointer to structure as first argument.
@@ -224,4 +250,3 @@ unexported fields cannot be set, and that field type and value type have to matc
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/oleiade/reflections/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/example_test.go
+++ b/example_test.go
@@ -2,9 +2,10 @@ package reflections_test
 
 import (
 	"fmt"
-	"github.com/oleiade/reflections"
 	"log"
 	"reflect"
+
+	"github.com/oleiade/reflections"
 )
 
 type MyStruct struct {
@@ -55,6 +56,32 @@ func ExampleGetFieldKind() {
 		log.Fatal(err)
 	}
 	fmt.Println(secondFieldKind)
+}
+
+func ExampleGetFieldType() {
+	s := MyStruct{
+		FirstField:  "first value",
+		SecondField: 2,
+		ThirdField:  "third value",
+	}
+
+	var firstFieldType string
+	var secondFieldType string
+	var err error
+
+	// GetFieldType will return reflect.String
+	firstFieldType, err = reflections.GetFieldType(s, "FirstField")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(firstFieldType)
+
+	// GetFieldType will return reflect.Int
+	secondFieldType, err = reflections.GetFieldType(s, "SecondField")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(secondFieldType)
 }
 
 func ExampleGetFieldTag() {

--- a/reflections.go
+++ b/reflections.go
@@ -52,6 +52,23 @@ func GetFieldKind(obj interface{}, name string) (reflect.Kind, error) {
 	return field.Type().Kind(), nil
 }
 
+// GetFieldType returns the kind of the provided obj field. obj can whether
+// be a structure or pointer to structure.
+func GetFieldType(obj interface{}, name string) (string, error) {
+	if !hasValidType(obj, []reflect.Kind{reflect.Struct, reflect.Ptr}) {
+		return "", errors.New("Cannot use GetField on a non-struct interface")
+	}
+
+	objValue := reflectValue(obj)
+	field := objValue.FieldByName(name)
+
+	if !field.IsValid() {
+		return "", fmt.Errorf("No such field: %s in obj", name)
+	}
+
+	return field.Type().String(), nil
+}
+
 // GetFieldTag returns the provided obj field tag value. obj can whether
 // be a structure or pointer to structure.
 func GetFieldTag(obj interface{}, fieldName, tagKey string) (string, error) {
@@ -61,7 +78,7 @@ func GetFieldTag(obj interface{}, fieldName, tagKey string) (string, error) {
 
 	objValue := reflectValue(obj)
 	objType := objValue.Type()
-	
+
 	field, ok := objType.FieldByName(fieldName)
 	if !ok {
 		return "", fmt.Errorf("No such field: %s in obj", fieldName)
@@ -193,15 +210,15 @@ func Tags(obj interface{}, key string) (map[string]string, error) {
 }
 
 func reflectValue(obj interface{}) reflect.Value {
-    var val reflect.Value
+	var val reflect.Value
 
-    if reflect.TypeOf(obj).Kind() == reflect.Ptr {
-        val = reflect.ValueOf(obj).Elem()
-    } else {
-        val = reflect.ValueOf(obj)
-    }
+	if reflect.TypeOf(obj).Kind() == reflect.Ptr {
+		val = reflect.ValueOf(obj).Elem()
+	} else {
+		val = reflect.ValueOf(obj)
+	}
 
-    return val
+	return val
 }
 
 func isExportableField(field reflect.StructField) bool {
@@ -209,7 +226,7 @@ func isExportableField(field reflect.StructField) bool {
 	return field.PkgPath == ""
 }
 
-func hasValidType(obj interface{}, types []reflect.Kind) bool{
+func hasValidType(obj interface{}, types []reflect.Kind) bool {
 	for _, t := range types {
 		if reflect.TypeOf(obj).Kind() == t {
 			return true

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -5,9 +5,10 @@
 package reflections
 
 import (
-	"github.com/stretchr/testify/assert"
-	"testing"
 	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestStruct struct {
@@ -107,6 +108,53 @@ func TestGetFieldKind_non_existing_field(t *testing.T) {
 	}
 
 	_, err := GetFieldKind(dummyStruct, "obladioblada")
+	assert.Error(t, err)
+}
+
+func TestGetFieldType_on_struct(t *testing.T) {
+	dummyStruct := TestStruct{
+		Dummy: "test",
+		Yummy: 123,
+	}
+
+	typeString, err := GetFieldType(dummyStruct, "Dummy")
+	assert.NoError(t, err)
+	assert.Equal(t, typeString, "string")
+
+	typeString, err = GetFieldType(dummyStruct, "Yummy")
+	assert.NoError(t, err)
+	assert.Equal(t, typeString, "int")
+}
+
+func TestGetFieldType_on_struct_pointer(t *testing.T) {
+	dummyStruct := &TestStruct{
+		Dummy: "test",
+		Yummy: 123,
+	}
+
+	typeString, err := GetFieldType(dummyStruct, "Dummy")
+	assert.NoError(t, err)
+	assert.Equal(t, typeString, "string")
+
+	typeString, err = GetFieldType(dummyStruct, "Yummy")
+	assert.NoError(t, err)
+	assert.Equal(t, typeString, "int")
+}
+
+func TestGetFieldType_on_non_struct(t *testing.T) {
+	dummy := "abc 123"
+
+	_, err := GetFieldType(dummy, "Dummy")
+	assert.Error(t, err)
+}
+
+func TestGetFieldType_non_existing_field(t *testing.T) {
+	dummyStruct := TestStruct{
+		Dummy: "test",
+		Yummy: 123,
+	}
+
+	_, err := GetFieldType(dummyStruct, "obladioblada")
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
This add a new function GetFieldType, which returns a the string literal of the field type. This is useful when a field is a struct, such as using a sql.NullInt64. It allows one to get the string type in order to assert on the field.