### PR TITLE
Go modules require a major-version suffix on the name

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/oleiade/reflections"
+	"github.com/oleiade/reflections/v1"
 )
 
 type MyStruct struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oleiade/reflections
+module github.com/oleiade/reflections/v1
 
 go 1.15
 


### PR DESCRIPTION
This adds the major-version suffix to the module name. This isn't actually required for v1, but when you bump to v2 it will break callers of the module without it (see https://golang.org/ref/mod#major-version-suffixes)