### PR TITLE
Update reflections.go

### DIFF
--- a/reflections.go
+++ b/reflections.go
@@ -41,7 +41,7 @@ func GetField(obj interface{}, name string) (interface{}, error) {
 		return nil, fmt.Errorf("no such field: %s in obj", name)
 	}
 
-	return field.Interface(), nil
+	return field, nil
 }
 
 // GetFieldKind returns the kind of the provided obj field.


### PR DESCRIPTION
when i use go version 1.19, it will throw the panic:
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
i change the " reflect.Interface{}" to "reflect", its ok.