### PR TITLE
replace strict field type check with AssignableTo

### DIFF
--- a/reflections.go
+++ b/reflections.go
@@ -141,8 +141,8 @@ func SetField(obj interface{}, name string, value interface{}) error {
 
 	structFieldType := structFieldValue.Type()
 	val := reflect.ValueOf(value)
-	if structFieldType != val.Type() {
-		invalidTypeError := fmt.Errorf("provided value type didn't match obj field type")
+	if !val.Type().AssignableTo(structFieldType) {
+		invalidTypeError := fmt.Errorf("provided value type not assignable to obj field type")
 		return invalidTypeError
 	}
 

--- a/reflections_test.go
+++ b/reflections_test.go
@@ -619,3 +619,23 @@ func TestFields_deep(t *testing.T) {
 	assert.Equal(t, fieldsDeep[1], "Street")
 	assert.Equal(t, fieldsDeep[2], "Number")
 }
+
+type SingleString string
+
+type StringList []string
+
+type Bar struct {
+	A StringList
+}
+
+func TestAssignable(t *testing.T) {
+	var b Bar
+	expected := []string{"a", "b", "c"}
+	assert.Nil(t, SetField(&b, "A", expected))
+	assert.Equal(t, StringList(expected), b.A)
+
+	err := SetField(&b, "A", []int{0, 1, 2})
+	assert.NotNil(t, err)
+	assert.Equal(t, "provided value type not assignable to obj field type",
+		err.Error())
+}


### PR DESCRIPTION
Allows for assignment in cases such as:

```go
type Foo string

type Foos []string

type Bar struct {
    A Foos
}

if err := reflections.SetField(&Bar{}, "A", []string{"a", "b", "c"}); err != nil {
    log.Fatal(err)
}
```